### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -24,6 +24,8 @@
 # This is the lint workflow for CI of FreeCAD
 
 name: Lint
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/13](https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/13)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Since this workflow primarily performs linting and analysis tasks, it likely only needs `contents: read` permission. This ensures the workflow can read the repository's contents without granting unnecessary write access.

The `permissions` block should be added immediately after the `name` field (line 26) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
