### PR TITLE
Potential fix for code scanning alert no. 14: Incomplete URL substring sanitization

### DIFF
--- a/src/Tools/SubWCRev.py
+++ b/src/Tools/SubWCRev.py
@@ -10,6 +10,7 @@
 # 2011/02/05: The script was extended to support also Bazaar
 
 import os, sys, re, time, getopt
+from urllib.parse import urlparse
 import xml.sax
 import xml.sax.handler
 import xml.sax.xmlreader
@@ -277,7 +278,7 @@ class GitControl(VersionControl):
                         url = "git://%s" % match.group(1)
                     entryscore = (
                         url == "git://github.com/FreeCAD/FreeCAD.git",
-                        "github.com" in url,
+                        urlparse(url).hostname == "github.com",
                         branch == self.branch,
                         branch == "main",
                         "@" not in url,


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/14](https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/14)

To fix the issue, the code should parse the `url` using `urllib.parse` to extract its hostname and then validate that the hostname matches `github.com`. This ensures that the check is performed on the correct part of the URL and avoids the risks associated with substring checks.

The following changes will be made:
1. Import the `urlparse` function from `urllib.parse`.
2. Replace the substring check `"github.com" in url` with a check that validates the hostname of the parsed URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
