### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sub_wrapup.yml
+++ b/.github/workflows/sub_wrapup.yml
@@ -32,8 +32,10 @@
 # ... report file shall be available in an artifact with the same name.
 
 name: WrapUp
+permissions:
+  contents: read
+  actions: read
 on:
-  workflow_call:
     inputs:
       previousSteps:
         type: string


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/12](https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/12)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. Based on the workflow's operations, the minimal permissions needed are likely `contents: read` (to access repository contents) and `actions: read` (to interact with artifacts). This ensures that the workflow has only the permissions it needs and no more.

The `permissions` block should be added immediately after the `name` field (line 34) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
