### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sub_prepare.yml
+++ b/.github/workflows/sub_prepare.yml
@@ -27,6 +27,9 @@
 
 name: Prepare
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/11](https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum required permissions. Based on the workflow's operations, the following permissions are needed:
- `contents: read` for accessing repository contents and commit details.
- `actions: read` for downloading artifacts from other workflows (if applicable).
- `id-token: write` for fetching an OpenID Connect token (if required in the future).

The `permissions` block will be added at the root level of the workflow, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
