### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sub_buildUbuntu2004.yml
+++ b/.github/workflows/sub_buildUbuntu2004.yml
@@ -26,6 +26,9 @@
 
 name: Build Ubuntu 20.04
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/10](https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily needs read access to the repository contents (`contents: read`) and possibly additional permissions for specific actions (e.g., `actions: read` for managing workflows or `packages: read` if interacting with packages). However, we will start with the minimal `contents: read` permission and expand only if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
