### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sub_buildWindows.yml
+++ b/.github/workflows/sub_buildWindows.yml
@@ -23,6 +23,8 @@
 # This workflow aims at building and testing FreeCAD on Windows using MSVC.
 
 name: Build Windows
+permissions:
+  contents: read
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/9](https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, it primarily needs `contents: read` to check out the source code and possibly interact with artifacts. No write permissions are necessary.

The `permissions` block will be added immediately after the `name` field (line 25) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
