### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -26,6 +26,9 @@
 
 name: Pixi Builds
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/8](https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for most CI workflows that do not need to modify repository contents. If any specific steps in the workflow require additional permissions, they can be added to the `permissions` block for the corresponding job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
