### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -26,6 +26,9 @@
 
 name: FreeCAD master CI
 
+permissions:
+  contents: read
+
 on: [workflow_dispatch, push, pull_request]
 
 concurrency:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/7](https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided details, most CI workflows only require `contents: read`. If additional permissions are needed for specific jobs, they can be defined within those jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
