### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI_cleanup.yml
+++ b/.github/workflows/CI_cleanup.yml
@@ -37,6 +37,10 @@
 
 name: FreeCAD CI cleaner
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   workflow_run:
     workflows: [FreeCAD master CI]


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/4](https://github.com/Git-Hub-Chris/FreeCAD/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it needs `contents: read` to access repository contents and `actions: write` to delete caches. These permissions will be explicitly defined to limit the scope of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
